### PR TITLE
Fix project bug

### DIFF
--- a/drivers.html
+++ b/drivers.html
@@ -142,13 +142,9 @@
         </div>
     </div>
 
-    <!-- Firebase Scripts -->
-    <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-app-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-auth-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-storage-compat.js"></script>
-    
-    <script src="js/config.js"></script>
+    <!-- Supabase Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="js/supabase-config.js"></script>
     <script src="js/auth-check.js"></script>
     <script src="js/drivers.js"></script>
 </body>


### PR DESCRIPTION
Switch `drivers.html` from Firebase to Supabase to resolve a runtime mismatch.

The `drivers.html` page was loading Firebase scripts while its associated JavaScript files (`js/drivers.js`, `js/auth-check.js`) were written for Supabase, leading to runtime errors and preventing driver data from loading. This change aligns the HTML page with the Supabase implementation.

---
<a href="https://cursor.com/background-agent?bcId=bc-344d9185-0519-4971-8208-ff7ecf4b3ea6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-344d9185-0519-4971-8208-ff7ecf4b3ea6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

